### PR TITLE
fetch repo info in parallel, then prompt

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
-	"github.com/google/go-github/v25/github"
+	"github.com/google/go-github/v28/github"
 )
 
 func NewClient() *github.Client {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.4.2
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/go-github/v25 v25.0.2
+	github.com/google/go-github/v28 v28.0.1
 	github.com/hashicorp/go-version v1.1.0
 	github.com/manifoldco/promptui v0.3.2
 	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v25 v25.0.2 h1:MqXE7nOlIF91NJ/PXAcvS2dC+XXCDbY7RvJzjyEPAoU=
 github.com/google/go-github/v25 v25.0.2/go.mod h1:6z5pC69qHtrPJ0sXPsj4BLnd82b+r6sLB7qcBoRZqpw=
+github.com/google/go-github/v28 v28.0.1 h1:SoHeOf40H2xIQpNzGHFeOJwDqPxvEVMyz97hDafpk0Y=
+github.com/google/go-github/v28 v28.0.1/go.mod h1:+5GboIspo7F0NG2qsvfYh7en6F3EK37uyqv+c35AR3s=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
@@ -79,6 +81,7 @@ github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4m
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/prompts.go
+++ b/prompts.go
@@ -47,6 +47,12 @@ func announceRepo(repo *Repository) {
 	)
 }
 
+func announceFetching() {
+	fmt.Println(
+		promptui.Styler(promptui.FGGreen)("Fetching repo info…"),
+	)
+}
+
 const version_format = "%-24s%10s\n"
 
 func announceVersions(project string, releases []*Release) {

--- a/prompts.go
+++ b/prompts.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/Masterminds/semver"
 	"github.com/manifoldco/promptui"
-	"github.com/google/go-github/v25/github"
+	"github.com/google/go-github/v28/github"
 )
 
 func promptToDelete(release *github.RepositoryRelease) bool {

--- a/release.go
+++ b/release.go
@@ -13,21 +13,21 @@ type Release struct {
 
 
 func cutRelease(repo *Repository) *Release {
+
 	release := &Release{
 		repository: repo,
-		version: repo.latestRelease(),
+		version: repo.latestRelease,
 	}
 
-	changeLog := repo.getChangelog(release.version)
-	if 0 == len(changeLog) {
+	if 0 == len(repo.changeLog) {
 		fmt.Printf("  skipping, no PRs found since %s\n", release.version.String())
 	} else {
-		newVersion := getVersion(release.version, changeLog)
+		newVersion := getVersion(release.version, repo.changeLog)
 		if newVersion != nil {
-			msg := composeReleaseMessage(changeLog)
+			msg := composeReleaseMessage(repo.changeLog)
 			repo.createRelease(newVersion, msg)
 			release.version = newVersion
-			announceRelease(repo, repo.latestRelease());
+			announceRelease(repo, repo.latestRelease);
 		}
 	}
 	return release

--- a/repository.go
+++ b/repository.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"context"
 	"github.com/Masterminds/semver"
-	"github.com/google/go-github/v25/github"
+	"github.com/google/go-github/v28/github"
 )
 
 

--- a/repository.go
+++ b/repository.go
@@ -11,10 +11,18 @@ import (
 )
 
 
+
+type ChangeLogEntry struct {
+	Number int
+	Message string
+}
+
 type Repository struct {
 	client *github.Client
 	owner string
 	name string
+	latestRelease *semver.Version
+	changeLog []ChangeLogEntry
 }
 
 func NewRepository(path string, client *github.Client) *Repository {
@@ -26,27 +34,9 @@ func NewRepository(path string, client *github.Client) *Repository {
 	};
 }
 
-func (r *Repository) latestRelease() *semver.Version {
-	ctx := context.Background()
-
-	release, _, err :=  r.client.Repositories.GetLatestRelease(
-		ctx, r.owner, r.name,
-	)
-	CheckError(err)
-
-	version, err :=  semver.NewVersion(*release.TagName)
-	CheckError(err)
-
-	return version
-}
 
 func (r *Repository) String() string {
 	return fmt.Sprintf("%s/%s", r.owner, r.name)
-}
-
-type ChangeLogEntry struct {
-	Number int
-	Message string
 }
 
 func (repo *Repository) getRecentReleases() []*github.RepositoryRelease {
@@ -61,20 +51,34 @@ func (repo *Repository) deleteRelease(release *github.RepositoryRelease) {
 	_, err := repo.client.Repositories.DeleteRelease(ctx, repo.owner, repo.name, *release.ID)
 	CheckError(err)
 }
-
-func (repo *Repository) getChangelog(previousRelease *semver.Version) []ChangeLogEntry {
+func (r *Repository) fetch() {
 	ctx := context.Background()
 
-	cmp, _, err := repo.client.Repositories.CompareCommits(
-		ctx, repo.owner, repo.name,
-		fmt.Sprintf("v%s", previousRelease.String()),
+	release, _, err :=  r.client.Repositories.GetLatestRelease(
+		ctx, r.owner, r.name,
+	)
+	CheckError(err)
+
+	version, err :=  semver.NewVersion(*release.TagName)
+	CheckError(err)
+
+	r.latestRelease = version
+
+
+
+// func (repo *Repository) getChangelog(previousRelease *semver.Version) []ChangeLogEntry {
+//	ctx := context.Background()
+
+	cmp, _, err := r.client.Repositories.CompareCommits(
+		ctx, r.owner, r.name,
+		fmt.Sprintf("v%s", version),
 		"master",
 	)
 	CheckError(err)
 
 	prNumR := regexp.MustCompile(`Merge pull request #(\d+) from (?:\S+)(?:\s+)(.*)`)
 
-	var log []ChangeLogEntry
+	//var log []ChangeLogEntry
 
 	for _, c := range cmp.Commits {
 		msg := *c.GetCommit().Message
@@ -82,12 +86,12 @@ func (repo *Repository) getChangelog(previousRelease *semver.Version) []ChangeLo
 		if len(prMatch) > 0 {
 			num, err := strconv.Atoi(prMatch[1])
 			CheckError(err)
-			log = append(log, ChangeLogEntry{
+			r.changeLog = append(r.changeLog, ChangeLogEntry{
 				Number: num, Message: prMatch[2],
 			})
 		}
 	}
-	return log
+//	return log
 }
 
 func (repo *Repository) createRelease(version *semver.Version, message string ) {

--- a/repository_test.go
+++ b/repository_test.go
@@ -16,8 +16,11 @@ func TestGetLatestRelease(t *testing.T) {
 		testMethod(t, r, "GET")
 		fmt.Fprintf(w, `{"id":1, "tag_name": "%s"}`, specifiedVersion)
 	})
-
-	parsedVersion := repo.latestRelease()
+	mux.HandleFunc("/repos/foo/bar/compare/v1.1.42...master",func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+	})
+	repo.fetch()
+	parsedVersion := repo.latestRelease
 	if parsedVersion.String() != specifiedVersion {
 		t.Errorf("Latest release is %s, wanted %s", parsedVersion.String(), specifiedVersion)
 	}

--- a/versionista_test.go
+++ b/versionista_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"net/http"
 	"net/http/httptest"
-	"github.com/google/go-github/v25/github"
+	"github.com/google/go-github/v28/github"
 
 )
 


### PR DESCRIPTION
Speeds up a release by a few seconds.

Before it would fetch the latest release, the changelog and then prompt for a release for each repository sequentially.

Now it fetched the latest release and changelog in parallel using goroutines, then prompts if needed