### PR TITLE
add review command to display latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ projects:
 
 ```
 
-to release all repos for a project run:
-`versionista release <project name>`
+## Commands
 
-Aternatively you can release any repo even if it's not listed by using the `organization/name` format like:
+* **release** all repos for a project: `versionista release <project name>`
+* **review**  display latest versions of all repos in project: `versionista review <project name>`
+
+Aternatively you can release or review any repository even if it's not listed by using the `organization/name` format like:
 `versionista release organization/name`
 
 

--- a/commands.go
+++ b/commands.go
@@ -41,7 +41,6 @@ func eachRepository(repoSpec string, iterFn func(*Repository)) {
 	wg.Wait()
 
 	for _, repo := range(repos) {
-		announceRepo(repo);
 		iterFn(repo)
 	}
 
@@ -51,7 +50,19 @@ func eachRepository(repoSpec string, iterFn func(*Repository)) {
 func releaseSpecifiedProject(cmd *cobra.Command, args []string) {
 	var releases []*Release
 	eachRepository(args[0], func(repo *Repository) {
-		releases = append(releases, cutRelease(repo))
+		announceRepo(repo);
+		releases = append(releases, newRelease(repo))
+	})
+	announceVersions(args[0], releases)
+}
+
+func reviewSpecifiedProject(cmd *cobra.Command, args []string) {
+	var releases []*Release
+	eachRepository(args[0], func(repo *Repository) {
+		releases = append(releases, &Release{
+			repository: repo,
+			version: repo.latestRelease,
+		})
 	})
 	announceVersions(args[0], releases)
 }
@@ -61,13 +72,19 @@ func configureCliCommands() {
 		Short: "versionista",
 	}
 
-	releaseCmd := &cobra.Command{
+	rootCmd.AddCommand(&cobra.Command{
 		Use:   "release",
 		Short: "release project(s)",
 		Args: cobra.MinimumNArgs(1),
 		Run: releaseSpecifiedProject,
-	}
-	rootCmd.AddCommand(releaseCmd)
+	})
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "review",
+		Short: "list latest version of project(s)",
+		Args: cobra.MinimumNArgs(1),
+		Run: reviewSpecifiedProject,
+	})
 
 	////////////////////////////////
 	// no mass deleting releases  //

--- a/release.go
+++ b/release.go
@@ -12,7 +12,7 @@ type Release struct {
 }
 
 
-func cutRelease(repo *Repository) *Release {
+func newRelease(repo *Repository) *Release {
 
 	release := &Release{
 		repository: repo,


### PR DESCRIPTION
Sometimes you need to re-run the report.  You could do that previously by skipping all the prompts but this is easier and doesn't have the possibility of inadvertently releasing stuff that should not be