### PR TITLE
match PRs that have a blank description

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -61,8 +61,9 @@ func (repo *Repository) deleteRelease(release *github.RepositoryRelease) {
 }
 
 var squashLine = regexp.MustCompile(`\s*(.*)\s+\(\#(\d+)\)`)
-var mergeLine = regexp.MustCompile(`Merge pull request #(\d+) from (?:\S+)(?:\s+)(.*)`)
-
+// match <number>, then non-greedily match any non-space, an optional space, then capture anything else
+var mergeLine = regexp.MustCompile(`Merge pull request #(\d+) from (?:\S+)(?:\s*)(.*)`)
+	
 func (r *Repository) fetch() {
 	ctx := context.Background()
 


### PR DESCRIPTION
the commit for https://github.com/openstax/bit-deployment/pull/13 didn't have a description 