### PR TITLE
Build the remote branch tip, not the stale local branch

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -86,7 +86,15 @@ func GenerateAssets(command, version, dir, sha string) (paths []string, err erro
 // or commit currently checked out, then checks out the ref (sha) being released
 // so generate-assets builds from the exact code that will be published. It
 // returns the original ref so the caller can restore it afterwards.
-func prepareRepo(dir, sha string) (string, error) {
+//
+// When ref is a branch name (the common case — the release config points at a
+// branch like "main"), prepareRepo fetches the remote first and checks out the
+// remote-tracking tip (origin/<branch>) rather than the possibly-stale LOCAL
+// branch, so a release always builds what is actually published on the remote —
+// not whatever the operator's local checkout happens to be. Fetch is best-effort:
+// a repo with no remote (e.g. tests, air-gapped builds) falls back to checking
+// out ref as-is, which also covers plain SHAs and tags.
+func prepareRepo(dir, ref string) (string, error) {
 	// Confirm dir is a git working tree.
 	if _, err := runGit(dir, "rev-parse", "--is-inside-work-tree"); err != nil {
 		return "", fmt.Errorf("%q is not a git repository: %w", dir, err)
@@ -106,11 +114,56 @@ func prepareRepo(dir, sha string) (string, error) {
 		return "", err
 	}
 
-	if _, err := runGit(dir, "checkout", sha); err != nil {
-		return "", fmt.Errorf("failed to checkout %q in %q: %w", sha, dir, err)
+	// Resolve the checkout target: prefer the up-to-date remote tip for a branch.
+	target := resolveCheckoutTarget(dir, ref)
+	if _, err := runGit(dir, "checkout", target); err != nil {
+		return "", fmt.Errorf("failed to checkout %q in %q: %w", target, dir, err)
 	}
 
 	return original, nil
+}
+
+// resolveCheckoutTarget decides what prepareRepo should actually check out for
+// the requested ref. If ref names a remote branch, it fetches that remote and
+// returns the remote-tracking ref (e.g. "origin/main"), so the build reflects the
+// published tip rather than a stale local branch. For SHAs, tags, or repos with
+// no matching remote branch, it returns ref unchanged. All remote probing is
+// best-effort — any failure falls back to ref so local-only repos still work.
+func resolveCheckoutTarget(dir, ref string) string {
+	remote := defaultRemote(dir)
+	if remote == "" {
+		return ref
+	}
+	// Only rewrite branch names; leave SHAs/tags alone. A ref is treated as a
+	// branch when the remote advertises it (ls-remote --heads matches a line).
+	heads, err := runGit(dir, "ls-remote", "--heads", remote, ref)
+	if err != nil || strings.TrimSpace(heads) == "" {
+		return ref
+	}
+	// Fetch just that branch so origin/<ref> is current, then target it.
+	if _, err := runGit(dir, "fetch", remote, ref); err != nil {
+		return ref // fetch failed — fall back to the local ref rather than abort.
+	}
+	return remote + "/" + ref
+}
+
+// defaultRemote returns the remote to fetch from — "origin" when present, else
+// the first configured remote, or "" when the repo has none (local-only).
+func defaultRemote(dir string) string {
+	out, err := runGit(dir, "remote")
+	if err != nil {
+		return ""
+	}
+	remotes := strings.Fields(out)
+	for _, r := range remotes {
+		if r == "origin" {
+			return "origin"
+		}
+	}
+	if len(remotes) > 0 {
+		return remotes[0]
+	}
+	return ""
 }
 
 // currentRef returns the branch name currently checked out at dir, or the

--- a/assets_test.go
+++ b/assets_test.go
@@ -212,3 +212,121 @@ func TestGenerateAssetsRestoresOriginalBranch(t *testing.T) {
 		t.Errorf("Expected to be restored to branch %q, got %q", branch, got)
 	}
 }
+
+// gitIn runs a git command in dir, failing the test on error.
+func gitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (in %s) failed: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestGenerateAssetsBuildsRemoteBranchTip is the regression test for the stale
+// local-branch bug: when the release ref is a BRANCH NAME and the remote is
+// ahead of the local branch, the build must run against the REMOTE tip (what is
+// actually published), not the operator's stale local checkout.
+func TestGenerateAssetsBuildsRemoteBranchTip(t *testing.T) {
+	// A bare repo acts as the remote, seeded with one commit via a scratch clone.
+	remote := t.TempDir()
+	gitIn(t, remote, "init", "-q", "--bare")
+
+	seed := t.TempDir()
+	gitIn(t, seed, "clone", "-q", remote, ".")
+	gitIn(t, seed, "config", "user.email", "t@example.com")
+	gitIn(t, seed, "config", "user.name", "T")
+	gitIn(t, seed, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(seed, "marker.txt"), []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, seed, "add", ".")
+	gitIn(t, seed, "commit", "-q", "-m", "v1")
+	branch := gitIn(t, seed, "rev-parse", "--abbrev-ref", "HEAD")
+	gitIn(t, seed, "push", "-q", "origin", branch)
+
+	// The operator's working copy: clone the remote at v1 (its local branch is now
+	// one commit BEHIND once we push v2 to the remote below).
+	work := t.TempDir()
+	gitIn(t, work, "clone", "-q", remote, ".")
+
+	// Advance the REMOTE to v2 via the seed clone. work's local branch still at v1.
+	if err := os.WriteFile(filepath.Join(seed, "marker.txt"), []byte("v2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, seed, "add", ".")
+	gitIn(t, seed, "commit", "-q", "-m", "v2")
+	gitIn(t, seed, "push", "-q", "origin", branch)
+
+	// Sanity: work's local branch is behind (still reads v1).
+	if got := gitIn(t, work, "show", "HEAD:marker.txt"); got != "v1" {
+		t.Fatalf("precondition: work should be at v1, got %q", got)
+	}
+
+	// Release by BRANCH NAME. The generate-assets command writes marker.txt's
+	// content to an output file so we can prove which commit was built.
+	outFile := filepath.Join(work, "built-content.txt")
+	cmd := "cp marker.txt " + outFile + " && echo " + outFile
+	if _, err := GenerateAssets(cmd, "1.0.0", work, branch); err != nil {
+		t.Fatalf("GenerateAssets returned error: %v", err)
+	}
+
+	built, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading built content: %v", err)
+	}
+	if strings.TrimSpace(string(built)) != "v2" {
+		t.Errorf("build ran against %q, want the remote tip %q — stale local branch was used", strings.TrimSpace(string(built)), "v2")
+	}
+
+	// And the working copy is restored to its original branch afterwards.
+	if got := gitIn(t, work, "rev-parse", "--abbrev-ref", "HEAD"); got != branch {
+		t.Errorf("expected restore to branch %q, got %q", branch, got)
+	}
+}
+
+// TestGenerateAssetsExplicitSHANotRewritten confirms that when the ref is a
+// commit SHA (not a branch), it is built as-is — the remote-branch resolution
+// must not hijack an explicit SHA.
+func TestGenerateAssetsExplicitSHANotRewritten(t *testing.T) {
+	remote := t.TempDir()
+	gitIn(t, remote, "init", "-q", "--bare")
+
+	work := t.TempDir()
+	gitIn(t, work, "clone", "-q", remote, ".")
+	gitIn(t, work, "config", "user.email", "t@example.com")
+	gitIn(t, work, "config", "user.name", "T")
+	gitIn(t, work, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(work, "marker.txt"), []byte("first"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, work, "add", ".")
+	gitIn(t, work, "commit", "-q", "-m", "first")
+	firstSHA := gitIn(t, work, "rev-parse", "HEAD")
+	branch := gitIn(t, work, "rev-parse", "--abbrev-ref", "HEAD")
+	gitIn(t, work, "push", "-q", "origin", branch)
+
+	// Second commit, pushed — so the branch tip differs from firstSHA.
+	if err := os.WriteFile(filepath.Join(work, "marker.txt"), []byte("second"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, work, "add", ".")
+	gitIn(t, work, "commit", "-q", "-m", "second")
+	gitIn(t, work, "push", "-q", "origin", branch)
+
+	outFile := filepath.Join(work, "built-content.txt")
+	cmd := "cp marker.txt " + outFile + " && echo " + outFile
+	if _, err := GenerateAssets(cmd, "1.0.0", work, firstSHA); err != nil {
+		t.Fatalf("GenerateAssets returned error: %v", err)
+	}
+
+	built, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading built content: %v", err)
+	}
+	if strings.TrimSpace(string(built)) != "first" {
+		t.Errorf("explicit SHA build ran against %q, want %q", strings.TrimSpace(string(built)), "first")
+	}
+}


### PR DESCRIPTION
## Problem

`prepareRepo` (in `assets.go`) checks out the release ref with a bare `git checkout <ref>` and **no fetch**. Since release configs point at a **branch name** (`GetBranch` returns `"main"`), a release builds whatever the operator's **local** `main` points at — which can be behind `origin/main`. The tag published to GitHub and the binary actually built can therefore disagree.

This caused a real stale release: a packaged app shipped pre-fix frontend even though the tag contained the fix, because the build ran against a local checkout (and, compounding it, a gitignored build artifact that survived the checkout).

## Fix

When the ref names a **remote branch**, fetch that remote and check out `origin/<branch>` — the published tip — instead of the local branch. For SHAs, tags, or repos with no matching remote (local-only builds and the test suite), fall back to the ref unchanged. All remote probing is best-effort so local-only usage is unaffected.

## Tests

- `TestGenerateAssetsBuildsRemoteBranchTip` — regression: local branch behind origin now builds the **remote** tip.
- `TestGenerateAssetsExplicitSHANotRewritten` — an explicit SHA is still built as-is.
- Existing tests (dirty-tree rejection, branch restore, local-only repos) unchanged and green; `go vet` clean.