### PR TITLE
Limit release body to GitHub's 125000-character maximum

### DIFF
--- a/changelog.go
+++ b/changelog.go
@@ -7,6 +7,14 @@ import (
 	"strings"
 )
 
+// MaxReleaseBodySize is GitHub's hard limit on the length of a release body.
+// Requests exceeding it are rejected with "body is too long (maximum is
+// 125000 characters)".
+const MaxReleaseBodySize = 125000
+
+// truncationNotice is appended to a description that had to be shortened.
+const truncationNotice = "… [truncated]"
+
 type Entry struct {
 	Number      int
 	Date        string
@@ -123,6 +131,88 @@ func BuildEntriesTableString(entries []Entry, jiraEnabled bool, jiraOrgId string
 	builder.WriteString("\n")
 
 	return builder.String()
+}
+
+// FitEntriesToBodyLimit builds the entries table so that prefix + table stays
+// within maxBodySize. If the full table would exceed the limit, the longest PR
+// descriptions are truncated (longest first) until the whole body fits. The
+// prefix argument accounts for any content prepended to the table (e.g. cross
+// links) so the combined body respects the limit.
+//
+// The returned entries slice is a copy with descriptions truncated as needed;
+// the caller's entries are not mutated.
+func FitEntriesToBodyLimit(prefix string, entries []Entry, jiraEnabled bool, jiraOrgId string, maxBodySize int) string {
+	// Work on a copy so we never mutate the caller's entries.
+	trimmed := make([]Entry, len(entries))
+	copy(trimmed, entries)
+
+	table := BuildEntriesTableString(trimmed, jiraEnabled, jiraOrgId)
+	if len(prefix)+len(table) <= maxBodySize {
+		return table
+	}
+
+	// Repeatedly shave the entry with the longest description until the body
+	// fits. Truncating the longest first spreads the loss across the biggest
+	// contributors and keeps the table structure intact for every PR.
+	for len(prefix)+len(table) > maxBodySize {
+		idx := longestDescriptionIndex(trimmed)
+		if idx < 0 {
+			// No description left to trim; nothing more we can do at this
+			// level. Return the smallest table we could produce.
+			break
+		}
+
+		overBy := (len(prefix) + len(table)) - maxBodySize
+		desc := trimmed[idx].Description
+		// Shrink this description by at least the overage, but never below
+		// zero. Removing `overBy` characters of the raw description removes at
+		// least that many characters from the rendered body.
+		newLen := len(desc) - overBy
+		if newLen < 0 {
+			newLen = 0
+		}
+		trimmed[idx].Description = truncateDescription(desc, newLen)
+
+		table = BuildEntriesTableString(trimmed, jiraEnabled, jiraOrgId)
+	}
+
+	return table
+}
+
+// longestDescriptionIndex returns the index of the entry with the longest
+// non-empty description, or -1 if no entry has a truncatable description.
+func longestDescriptionIndex(entries []Entry) int {
+	idx := -1
+	max := 0
+	for i, e := range entries {
+		// A description already at or below the truncation notice cannot be
+		// shortened any further usefully.
+		if len(e.Description) > len(truncationNotice) && len(e.Description) > max {
+			max = len(e.Description)
+			idx = i
+		}
+	}
+	return idx
+}
+
+// truncateDescription shortens desc so its rendered length is at most roughly
+// targetLen, appending a notice so readers know content was dropped. A
+// targetLen of 0 (or one too small to fit the notice) collapses to just the
+// notice.
+func truncateDescription(desc string, targetLen int) string {
+	if targetLen <= len(truncationNotice) {
+		return truncationNotice
+	}
+	keep := targetLen - len(truncationNotice)
+	if keep >= len(desc) {
+		return desc
+	}
+	// Trim on a rune boundary so we never split a multi-byte character.
+	runes := []rune(desc)
+	if keep > len(runes) {
+		keep = len(runes)
+	}
+	return strings.TrimRight(string(runes[:keep]), " ") + truncationNotice
 }
 
 

--- a/changelog_test.go
+++ b/changelog_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -361,6 +362,136 @@ func TestBuildEntriesTableString(t *testing.T) {
 	}
 	if !strings.Contains(result, "[TEST-456](https://my-org.atlassian.net/browse/TEST-456)") {
 		t.Error("Expected normalized ticket reference")
+	}
+}
+
+func TestFitEntriesToBodyLimitUnderLimit(t *testing.T) {
+	entries := []Entry{
+		{Number: 1, Date: "2023-01-01", Author: "a", Title: "Title", Description: "short desc"},
+	}
+
+	// A generous limit means no truncation and identical output to the plain builder.
+	got := FitEntriesToBodyLimit("", entries, false, "", MaxReleaseBodySize)
+	want := BuildEntriesTableString(entries, false, "")
+	if got != want {
+		t.Errorf("expected unchanged table under the limit\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestFitEntriesToBodyLimitTruncatesLongest(t *testing.T) {
+	entries := []Entry{
+		{Number: 1, Date: "2023-01-01", Author: "a", Title: "Small", Description: "tiny"},
+		{Number: 2, Date: "2023-01-02", Author: "b", Title: "Big", Description: strings.Repeat("x", 5000)},
+	}
+
+	limit := 1000
+	got := FitEntriesToBodyLimit("", entries, false, "", limit)
+
+	if len(got) > limit {
+		t.Fatalf("expected body within %d chars, got %d", limit, len(got))
+	}
+	// Both PRs must still be present in the table.
+	if !strings.Contains(got, "| #1 |") || !strings.Contains(got, "| #2 |") {
+		t.Errorf("expected both PR rows to remain, got: %q", got)
+	}
+	// The large description must be truncated with a notice.
+	if !strings.Contains(got, truncationNotice) {
+		t.Errorf("expected truncation notice in body, got: %q", got)
+	}
+	// The small, untouched description should survive intact.
+	if !strings.Contains(got, "tiny") {
+		t.Errorf("expected small description to remain, got: %q", got)
+	}
+}
+
+func TestFitEntriesToBodyLimitAccountsForPrefix(t *testing.T) {
+	entries := []Entry{
+		{Number: 1, Date: "2023-01-01", Author: "a", Title: "Big", Description: strings.Repeat("x", 5000)},
+	}
+
+	limit := 2000
+	prefix := strings.Repeat("p", 1500)
+	table := FitEntriesToBodyLimit(prefix, entries, false, "", limit)
+
+	if len(prefix)+len(table) > limit {
+		t.Fatalf("expected prefix+table within %d chars, got %d", limit, len(prefix)+len(table))
+	}
+}
+
+func TestFitEntriesToBodyLimitDoesNotMutateInput(t *testing.T) {
+	original := strings.Repeat("y", 5000)
+	entries := []Entry{
+		{Number: 1, Date: "2023-01-01", Author: "a", Title: "Big", Description: original},
+	}
+
+	FitEntriesToBodyLimit("", entries, false, "", 500)
+
+	if entries[0].Description != original {
+		t.Errorf("expected caller's entries to be unmodified, description changed")
+	}
+}
+
+func TestTruncateDescription(t *testing.T) {
+	tests := []struct {
+		name      string
+		desc      string
+		targetLen int
+	}{
+		{name: "target below notice collapses to notice", desc: "hello world", targetLen: 3},
+		{name: "target larger than desc returns desc", desc: "hello", targetLen: 100},
+		{name: "trims to target", desc: strings.Repeat("z", 100), targetLen: 40},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateDescription(tt.desc, tt.targetLen)
+			if tt.targetLen >= len(tt.desc) {
+				if got != tt.desc {
+					t.Errorf("expected unchanged desc, got %q", got)
+				}
+				return
+			}
+			if tt.targetLen <= len(truncationNotice) {
+				if got != truncationNotice {
+					t.Errorf("expected bare notice, got %q", got)
+				}
+				return
+			}
+			if len(got) > tt.targetLen {
+				t.Errorf("expected result within %d chars, got %d (%q)", tt.targetLen, len(got), got)
+			}
+			if !strings.HasSuffix(got, truncationNotice) {
+				t.Errorf("expected truncation notice suffix, got %q", got)
+			}
+		})
+	}
+}
+
+func TestFitEntriesToBodyLimitJiraTable(t *testing.T) {
+	// Ensure the fit logic works when the ticket column is enabled and there
+	// are many entries contributing to the size.
+	var entries []Entry
+	for i := 0; i < 50; i++ {
+		entries = append(entries, Entry{
+			Number:      i,
+			Date:        "2023-01-01",
+			Author:      "author",
+			Title:       "Title",
+			Description: strings.Repeat("d", 4000),
+			Tickets:     []string{"TEST-1"},
+		})
+	}
+
+	limit := 20000
+	got := FitEntriesToBodyLimit("", entries, true, "org", limit)
+	if len(got) > limit {
+		t.Fatalf("expected body within %d chars, got %d", limit, len(got))
+	}
+	// All rows should still be present.
+	for i := 0; i < 50; i++ {
+		if !strings.Contains(got, "| #"+strconv.Itoa(i)+" |") {
+			t.Errorf("expected PR #%d row to remain", i)
+		}
 	}
 }
 

--- a/release.go
+++ b/release.go
@@ -230,7 +230,8 @@ func (m *Manager) AppendToRelease(ctx context.Context, repo *ReleaseRepository, 
 	}
 
 	header := fmt.Sprintf("\n## Appended %s (%s)\n\n", time.Now().Format("2006-01-02"), shortSHA(newSHA))
-	newBody := release.GetBody() + header + BuildEntriesTableString(entries, repo.JiraEnabled, m.jiraOrgId)
+	prefix := release.GetBody() + header
+	newBody := prefix + FitEntriesToBodyLimit(prefix, entries, repo.JiraEnabled, m.jiraOrgId, MaxReleaseBodySize)
 
 	if m.dryRun {
 		m.logger.Info("[DRY RUN] Would append %d entries to release %s for %s and move tag to %s",
@@ -382,9 +383,10 @@ func (m *Manager) CreateReleaseFromEntries(ctx context.Context, repo *ReleaseRep
 	entries []Entry, crossLinks []CrossLink, releaseType Type) error {
 	
 	var builder strings.Builder
-	builder.WriteString(BuildCrossLinksString(crossLinks))
+	prefix := BuildCrossLinksString(crossLinks)
+	builder.WriteString(prefix)
 	if len(entries) > 0 {
-		builder.WriteString(BuildEntriesTableString(entries, repo.JiraEnabled, m.jiraOrgId))
+		builder.WriteString(FitEntriesToBodyLimit(prefix, entries, repo.JiraEnabled, m.jiraOrgId, MaxReleaseBodySize))
 	}
 	releaseNotes := builder.String()
 	return m.CreateRelease(ctx, repo, newVersion, releaseNotes, releaseType)
@@ -536,9 +538,10 @@ func (m *Manager) ProcessReleaseInteractiveWithEntries(ctx context.Context, repo
 	}
 
 	var builder strings.Builder
-	builder.WriteString(BuildCrossLinksString(crossLinks))
+	prefix := BuildCrossLinksString(crossLinks)
+	builder.WriteString(prefix)
 	if len(entries) > 0 {
-		builder.WriteString(BuildEntriesTableString(entries, repo.JiraEnabled, m.jiraOrgId))
+		builder.WriteString(FitEntriesToBodyLimit(prefix, entries, repo.JiraEnabled, m.jiraOrgId, MaxReleaseBodySize))
 	}
 	releaseNotes := builder.String()
 


### PR DESCRIPTION
GitHub rejects release bodies over 125000 characters (`body is too long (maximum is 125000 characters)`).

Adds `FitEntriesToBodyLimit`, which truncates the longest PR descriptions (longest first) until the body fits under the limit, keeping every PR row intact. Wired into the create, interactive, and append release paths. The prefix (cross-links / existing body) is counted toward the limit.

https://claude.ai/code/session_018YZC7c73iDNVXLQoevwsym